### PR TITLE
Increasing the default timeout when using Truffle Dashboard

### DIFF
--- a/smart-contract/hardhat.config.ts
+++ b/smart-contract/hardhat.config.ts
@@ -100,6 +100,7 @@ const config: HardhatUserConfig = {
   networks: {
     truffle: {
       url: 'http://localhost:24012/rpc',
+      timeout: 60000,
     },
   },
   gasReporter: {


### PR DESCRIPTION
The default network configuration in Hardhat has a transaction timeout of 20 seconds (source: https://hardhat.org/config/#json-rpc-based-networks). I decided to increase it to 60 seconds when using Truffle Dashboard in order to leave time to properly inspect the transaction details on MetaMask.