### PR TITLE
Add post mint status message for dapp

### DIFF
--- a/minting-dapp/package.json
+++ b/minting-dapp/package.json
@@ -22,6 +22,7 @@
         "postcss-loader": "^6.2.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-toastify": "^9.0.3",
         "regenerator-runtime": "^0.13.2",
         "sass": "^1.45.0",
         "sass-loader": "^12.4.0",
@@ -36,8 +37,5 @@
         "dev": "encore dev",
         "watch": "encore dev --watch",
         "build": "encore production --progress"
-    },
-    "dependencies": {
-        "react-toastify": "^9.0.3"
     }
 }

--- a/minting-dapp/package.json
+++ b/minting-dapp/package.json
@@ -36,5 +36,8 @@
         "dev": "encore dev",
         "watch": "encore dev --watch",
         "build": "encore production --progress"
+    },
+    "dependencies": {
+        "react-toastify": "^9.0.3"
     }
 }

--- a/minting-dapp/src/scripts/main.tsx
+++ b/minting-dapp/src/scripts/main.tsx
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           autoClose={5000}
           closeOnClick={true}
           pauseOnHover={true}
-          theme={'light'} />
+          theme='light' />
     <Dapp />
   </>, document.getElementById('minting-dapp'));
 });

--- a/minting-dapp/src/scripts/main.tsx
+++ b/minting-dapp/src/scripts/main.tsx
@@ -1,13 +1,23 @@
 import '../styles/main.scss';
+import 'react-toastify/dist/ReactToastify.css';
 
 import ReactDOM from 'react-dom';
 import Dapp from './react/Dapp';
 import CollectionConfig from '../../../smart-contract/config/CollectionConfig';
+import { ToastContainer } from 'react-toastify';
 
 if (document.title === '') {
   document.title = CollectionConfig.tokenName;
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-  ReactDOM.render(<Dapp />, document.getElementById('minting-dapp'));
+  ReactDOM.render(<>
+    <ToastContainer
+          position='top-left'
+          autoClose={5000}
+          closeOnClick={true}
+          pauseOnHover={true}
+          theme={'light'} />
+    <Dapp />
+  </>, document.getElementById('minting-dapp'));
 });

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -97,7 +97,9 @@ export default class Dapp extends React.Component<Props, State> {
   async whitelistMintTokens(amount: number): Promise<void>
   {
     try {
-      await this.contract.whitelistMint(amount, Whitelist.getProofForAddress(this.state.userAddress!), {value: this.state.tokenPrice.mul(amount)});
+      this.setState({ mintedTransaction: null });
+      let transaction = await this.contract.whitelistMint(amount, Whitelist.getProofForAddress(this.state.userAddress!), {value: this.state.tokenPrice.mul(amount)});
+      this.setState({ mintedTransaction: transaction.hash });
     } catch (e) {
       this.setError(e);
     }

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -27,6 +27,7 @@ interface State {
   isUserInWhitelist: boolean;
   merkleProofManualAddress: string;
   merkleProofManualAddressFeedbackMessage: string|JSX.Element|null;
+  mintedTransaction: string|null;
   errorMessage: string|JSX.Element|null;
 }
 
@@ -43,6 +44,7 @@ const defaultState: State = {
   isUserInWhitelist: false,
   merkleProofManualAddress: '',
   merkleProofManualAddressFeedbackMessage: null,
+  mintedTransaction: null,
   errorMessage: null,
 };
 
@@ -84,7 +86,9 @@ export default class Dapp extends React.Component<Props, State> {
   async mintTokens(amount: number): Promise<void>
   {
     try {
-      await this.contract.mint(amount, {value: this.state.tokenPrice.mul(amount)});
+      this.setState({ mintedTransaction: null });
+      let transaction = await this.contract.mint(amount, {value: this.state.tokenPrice.mul(amount)});
+      this.setState({ mintedTransaction: transaction.hash });
     } catch (e) {
       this.setError(e);
     }
@@ -107,6 +111,11 @@ export default class Dapp extends React.Component<Props, State> {
   private isContractReady(): boolean
   {
     return this.contract !== undefined;
+  }
+
+  private isMinting(): boolean
+  {
+    return this.state.mintedTransaction !== null && this.state.errorMessage === null;
   }
 
   private isSoldOut(): boolean
@@ -153,8 +162,24 @@ export default class Dapp extends React.Component<Props, State> {
           : null}
 
         {this.state.errorMessage ? <div className="error"><p>{this.state.errorMessage}</p><button onClick={() => this.setError()}>Close</button></div> : null}
-        
-        {this.isWalletConnected() ?
+
+        {this.isMinting() ?
+          <div className="mint-initiated">
+            <p>
+              View the <a href={this.generateTransactionUrl()} target="_blank">transaction status</a> directly on the blockchain.
+              Once complete, view the minted NFT in many ways:
+            </p>
+            <p>
+              <ul>
+                <li><a href={this.generateTokenUrl()} target="_blank">Etherscan</a></li>
+                <li><a href={this.generateMarketplaceUrl()} target="_blank">OpenSea</a></li>
+                <li><a href="https://metamask.app.link/skAH3BaF99" target="_blank">MetaMask</a></li>
+                <li><a href="https://rainbow.me" target="_blank">Rainbow</a></li>
+              </ul>
+            </p>
+            <button onClick={() => window.location.reload()} className="primary">Mint Another</button>
+          </div>
+          : this.isWalletConnected() ?
           <>
             {this.isContractReady() ?
               <>
@@ -251,6 +276,7 @@ export default class Dapp extends React.Component<Props, State> {
     }
 
     this.setState({
+      mintedTransaction: null,
       errorMessage: null === errorMessage ? null : errorMessage.charAt(0).toUpperCase() + errorMessage.slice(1),
     });
   }
@@ -258,6 +284,18 @@ export default class Dapp extends React.Component<Props, State> {
   private generateContractUrl(): string
   {
     return this.state.networkConfig.blockExplorer.generateContractUrl(CollectionConfig.contractAddress!);
+  }
+
+  private generateTransactionUrl(): string
+  {
+    return this.state.mintedTransaction
+      ? this.state.networkConfig.blockExplorer.generateTransactionUrl(this.state.mintedTransaction)
+      : '#';
+  }
+
+  private generateTokenUrl(): string
+  {
+    return this.state.networkConfig.blockExplorer.generateTokenUrl(CollectionConfig.contractAddress!);
   }
 
   private generateMarketplaceUrl(): string

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -91,7 +91,7 @@ export default class Dapp extends React.Component<Props, State> {
       const transaction = await this.contract.mint(amount, {value: this.state.tokenPrice.mul(amount)});
 
       toast.info(<>
-        Transaction sent! Waiting...<br/>
+        Transaction sent! Please wait...<br/>
         <a href={this.generateTransactionUrl(transaction.hash)} target="_blank" rel="noopener">View on {this.state.networkConfig.blockExplorer.name}</a>
       </>);
 
@@ -115,15 +115,15 @@ export default class Dapp extends React.Component<Props, State> {
       const transaction = await this.contract.whitelistMint(amount, Whitelist.getProofForAddress(this.state.userAddress!), {value: this.state.tokenPrice.mul(amount)});
 
       toast.info(<>
-        Transaction sent! Waiting...<br/>
-        <p>{transaction.hash}</p>
+        Transaction sent! Please wait...<br/>
+        <a href={this.generateTransactionUrl(transaction.hash)} target="_blank" rel="noopener">View on {this.state.networkConfig.blockExplorer.name}</a>
       </>);
 
       const receipt = await transaction.wait();
 
       toast.success(<>
         Success!<br />
-        <p>{receipt.transactionHash}</p>
+        <a href={this.generateTransactionUrl(receipt.transactionHash)} target="_blank" rel="noopener">View on {this.state.networkConfig.blockExplorer.name}</a>
       </>);
     } catch (e) {
       this.setError(e);

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -8,6 +8,7 @@ import NetworkConfigInterface from '../../../../smart-contract/lib/NetworkConfig
 import CollectionStatus from './CollectionStatus';
 import MintWidget from './MintWidget';
 import Whitelist from '../lib/Whitelist';
+import { toast } from 'react-toastify';
 
 const ContractAbi = require('../../../../smart-contract/artifacts/contracts/' + CollectionConfig.contractName + '.sol/' + CollectionConfig.contractName + '.json').abi;
 
@@ -23,6 +24,7 @@ interface State {
   maxMintAmountPerTx: number;
   tokenPrice: BigNumber;
   isPaused: boolean;
+  loading: boolean;
   isWhitelistMintEnabled: boolean;
   isUserInWhitelist: boolean;
   merkleProofManualAddress: string;
@@ -39,6 +41,7 @@ const defaultState: State = {
   maxMintAmountPerTx: 0,
   tokenPrice: BigNumber.from(0),
   isPaused: true,
+  loading: false,
   isWhitelistMintEnabled: false,
   isUserInWhitelist: false,
   merkleProofManualAddress: '',
@@ -63,7 +66,7 @@ export default class Dapp extends React.Component<Props, State> {
     const browserProvider = await detectEthereumProvider() as ExternalProvider;
 
     if (browserProvider?.isMetaMask !== true) {
-      this.setError( 
+      this.setError(
         <>
           We were not able to detect <strong>MetaMask</strong>. We value <strong>privacy and security</strong> a lot so we limit the wallet options on the DAPP.<br />
           <br />
@@ -84,16 +87,44 @@ export default class Dapp extends React.Component<Props, State> {
   async mintTokens(amount: number): Promise<void>
   {
     try {
-      await this.contract.mint(amount, {value: this.state.tokenPrice.mul(amount)});
+      this.setState({loading: true});
+      const transaction = await this.contract.mint(amount, {value: this.state.tokenPrice.mul(amount)});
+
+      toast.info(<>
+        Transaction sent! Waiting...<br/>
+        <a href={this.generateTransactionUrl(transaction.hash)}>View on {this.state.networkConfig.blockExplorer.name}</a>
+      </>);
+
+      const receipt = await transaction.wait();
+
+      toast.success(<>
+        Success!<br />
+        <a href={this.generateTransactionUrl(receipt.transactionHash)}>View on {this.state.networkConfig.blockExplorer.name}</a>
+      </>);
+
+      this.setState({loading: false});
     } catch (e) {
       this.setError(e);
+      this.setState({loading: false});
     }
   }
 
   async whitelistMintTokens(amount: number): Promise<void>
   {
     try {
-      await this.contract.whitelistMint(amount, Whitelist.getProofForAddress(this.state.userAddress!), {value: this.state.tokenPrice.mul(amount)});
+      const transaction = await this.contract.whitelistMint(amount, Whitelist.getProofForAddress(this.state.userAddress!), {value: this.state.tokenPrice.mul(amount)});
+
+      toast.info(<>
+        Transaction sent! Waiting...<br/>
+        <p>{transaction.hash}</p>
+      </>);
+
+      const receipt = await transaction.wait();
+
+      toast.success(<>
+        Success!<br />
+        <p>{receipt.transactionHash}</p>
+      </>);
     } catch (e) {
       this.setError(e);
     }
@@ -134,7 +165,7 @@ export default class Dapp extends React.Component<Props, State> {
     navigator.clipboard.writeText(merkleProof);
 
     this.setState({
-      merkleProofManualAddressFeedbackMessage: 
+      merkleProofManualAddressFeedbackMessage:
       <>
         <strong>Congratulations!</strong> <span className="emoji">🎉</span><br />
         Your Merkle Proof <strong>has been copied to the clipboard</strong>. You can paste it into <a href={this.generateContractUrl()} target="_blank">{this.state.networkConfig.blockExplorer.name}</a> to claim your tokens.
@@ -153,7 +184,7 @@ export default class Dapp extends React.Component<Props, State> {
           : null}
 
         {this.state.errorMessage ? <div className="error"><p>{this.state.errorMessage}</p><button onClick={() => this.setError()}>Close</button></div> : null}
-        
+
         {this.isWalletConnected() ?
           <>
             {this.isContractReady() ?
@@ -179,6 +210,7 @@ export default class Dapp extends React.Component<Props, State> {
                     isUserInWhitelist={this.state.isUserInWhitelist}
                     mintTokens={(mintAmount) => this.mintTokens(mintAmount)}
                     whitelistMintTokens={(mintAmount) => this.whitelistMintTokens(mintAmount)}
+                    loading={this.state.loading}
                   />
                   :
                   <div className="collection-sold-out">
@@ -202,7 +234,7 @@ export default class Dapp extends React.Component<Props, State> {
         :
           <div className="no-wallet">
             {!this.isWalletConnected() ? <button className="primary" disabled={this.provider === undefined} onClick={() => this.connectWallet()}>Connect Wallet</button> : null}
-            
+
             <div className="use-block-explorer">
               Hey, looking for a <strong>super-safe experience</strong>? <span className="emoji">😃</span><br />
               You can interact with the smart-contract <strong>directly</strong> through <a href={this.generateContractUrl()} target="_blank">{this.state.networkConfig.blockExplorer.name}</a>, without even connecting your wallet to this DAPP! <span className="emoji">🚀</span><br />
@@ -245,7 +277,7 @@ export default class Dapp extends React.Component<Props, State> {
         errorMessage = error.message;
       } else if (React.isValidElement(error)) {
         this.setState({errorMessage: error});
-  
+
         return;
       }
     }
@@ -265,6 +297,11 @@ export default class Dapp extends React.Component<Props, State> {
     return CollectionConfig.marketplaceConfig.generateCollectionUrl(CollectionConfig.marketplaceIdentifier, !this.isNotMainnet());
   }
 
+  private generateTransactionUrl(transactionHash: string): string
+  {
+    return this.state.networkConfig.blockExplorer.generateTransactionUrl(transactionHash);
+  }
+
   private async connectWallet(): Promise<void>
   {
     try {
@@ -279,7 +316,7 @@ export default class Dapp extends React.Component<Props, State> {
   private async initWallet(): Promise<void>
   {
     const walletAccounts = await this.provider.listAccounts();
-    
+
     this.setState(defaultState);
 
     if (walletAccounts.length === 0) {
@@ -298,7 +335,7 @@ export default class Dapp extends React.Component<Props, State> {
 
       return;
     }
-    
+
     this.setState({
       userAddress: walletAccounts[0],
       network,

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -27,7 +27,6 @@ interface State {
   isUserInWhitelist: boolean;
   merkleProofManualAddress: string;
   merkleProofManualAddressFeedbackMessage: string|JSX.Element|null;
-  mintedTransaction: string|null;
   errorMessage: string|JSX.Element|null;
 }
 
@@ -44,7 +43,6 @@ const defaultState: State = {
   isUserInWhitelist: false,
   merkleProofManualAddress: '',
   merkleProofManualAddressFeedbackMessage: null,
-  mintedTransaction: null,
   errorMessage: null,
 };
 
@@ -86,9 +84,7 @@ export default class Dapp extends React.Component<Props, State> {
   async mintTokens(amount: number): Promise<void>
   {
     try {
-      this.setState({ mintedTransaction: null });
-      let transaction = await this.contract.mint(amount, {value: this.state.tokenPrice.mul(amount)});
-      this.setState({ mintedTransaction: transaction.hash });
+      await this.contract.mint(amount, {value: this.state.tokenPrice.mul(amount)});
     } catch (e) {
       this.setError(e);
     }
@@ -111,11 +107,6 @@ export default class Dapp extends React.Component<Props, State> {
   private isContractReady(): boolean
   {
     return this.contract !== undefined;
-  }
-
-  private isMinting(): boolean
-  {
-    return this.state.mintedTransaction !== null && this.state.errorMessage === null;
   }
 
   private isSoldOut(): boolean
@@ -162,24 +153,8 @@ export default class Dapp extends React.Component<Props, State> {
           : null}
 
         {this.state.errorMessage ? <div className="error"><p>{this.state.errorMessage}</p><button onClick={() => this.setError()}>Close</button></div> : null}
-
-        {this.isMinting() ?
-          <div className="mint-initiated">
-            <p>
-              View the <a href={this.generateTransactionUrl()} target="_blank">transaction status</a> directly on the blockchain.
-              Once complete, view the minted NFT in many ways:
-            </p>
-            <p>
-              <ul>
-                <li><a href={this.generateTokenUrl()} target="_blank">Etherscan</a></li>
-                <li><a href={this.generateMarketplaceUrl()} target="_blank">OpenSea</a></li>
-                <li><a href="https://metamask.app.link/skAH3BaF99" target="_blank">MetaMask</a></li>
-                <li><a href="https://rainbow.me" target="_blank">Rainbow</a></li>
-              </ul>
-            </p>
-            <button onClick={() => window.location.reload()} className="primary">Mint Another</button>
-          </div>
-          : this.isWalletConnected() ?
+        
+        {this.isWalletConnected() ?
           <>
             {this.isContractReady() ?
               <>
@@ -276,7 +251,6 @@ export default class Dapp extends React.Component<Props, State> {
     }
 
     this.setState({
-      mintedTransaction: null,
       errorMessage: null === errorMessage ? null : errorMessage.charAt(0).toUpperCase() + errorMessage.slice(1),
     });
   }
@@ -284,18 +258,6 @@ export default class Dapp extends React.Component<Props, State> {
   private generateContractUrl(): string
   {
     return this.state.networkConfig.blockExplorer.generateContractUrl(CollectionConfig.contractAddress!);
-  }
-
-  private generateTransactionUrl(): string
-  {
-    return this.state.mintedTransaction
-      ? this.state.networkConfig.blockExplorer.generateTransactionUrl(this.state.mintedTransaction)
-      : '#';
-  }
-
-  private generateTokenUrl(): string
-  {
-    return this.state.networkConfig.blockExplorer.generateTokenUrl(CollectionConfig.contractAddress!);
   }
 
   private generateMarketplaceUrl(): string

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -92,14 +92,14 @@ export default class Dapp extends React.Component<Props, State> {
 
       toast.info(<>
         Transaction sent! Waiting...<br/>
-        <a href={this.generateTransactionUrl(transaction.hash)}>View on {this.state.networkConfig.blockExplorer.name}</a>
+        <a href={this.generateTransactionUrl(transaction.hash)} target="_blank" rel="noopener">View on {this.state.networkConfig.blockExplorer.name}</a>
       </>);
 
       const receipt = await transaction.wait();
 
       toast.success(<>
         Success!<br />
-        <a href={this.generateTransactionUrl(receipt.transactionHash)}>View on {this.state.networkConfig.blockExplorer.name}</a>
+        <a href={this.generateTransactionUrl(receipt.transactionHash)} target="_blank" rel="noopener">View on {this.state.networkConfig.blockExplorer.name}</a>
       </>);
 
       this.setState({loading: false});

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -97,9 +97,7 @@ export default class Dapp extends React.Component<Props, State> {
   async whitelistMintTokens(amount: number): Promise<void>
   {
     try {
-      this.setState({ mintedTransaction: null });
-      let transaction = await this.contract.whitelistMint(amount, Whitelist.getProofForAddress(this.state.userAddress!), {value: this.state.tokenPrice.mul(amount)});
-      this.setState({ mintedTransaction: transaction.hash });
+      await this.contract.whitelistMint(amount, Whitelist.getProofForAddress(this.state.userAddress!), {value: this.state.tokenPrice.mul(amount)});
     } catch (e) {
       this.setError(e);
     }

--- a/minting-dapp/src/scripts/react/MintWidget.tsx
+++ b/minting-dapp/src/scripts/react/MintWidget.tsx
@@ -9,6 +9,7 @@ interface Props {
   tokenPrice: BigNumber;
   maxMintAmountPerTx: number;
   isPaused: boolean;
+  loading: boolean;
   isWhitelistMintEnabled: boolean;
   isUserInWhitelist: boolean;
   mintTokens(mintAmount: number): Promise<void>;
@@ -64,7 +65,7 @@ export default class MintWidget extends React.Component<Props, State> {
     return (
       <>
         {this.canMint() ?
-          <div className="mint-widget">
+          <div className={`mint-widget ${this.props.loading ? 'animate-pulse saturate-0 pointer-events-none' : ''}`}>
             <div className="preview">
               <img src="/build/images/preview.png" alt="Collection preview" />
             </div>
@@ -74,16 +75,16 @@ export default class MintWidget extends React.Component<Props, State> {
             </div>
 
             <div className="controls">
-              <button className="decrease" onClick={() => this.decrementMintAmount()}>-</button>
+              <button className="decrease" disabled={this.props.loading} onClick={() => this.decrementMintAmount()}>-</button>
               <span className="mint-amount">{this.state.mintAmount}</span>
-              <button className="increase" onClick={() => this.incrementMintAmount()}>+</button>
-              <button className="primary" onClick={() => this.mint()}>Mint</button>
+              <button className="increase" disabled={this.props.loading} onClick={() => this.incrementMintAmount()}>+</button>
+              <button className="primary" disabled={this.props.loading} onClick={() => this.mint()}>Mint</button>
             </div>
           </div>
           :
           <div className="cannot-mint">
             <span className="emoji">⏳</span>
-            
+
             {this.props.isWhitelistMintEnabled ? <>You are not included in the <strong>whitelist</strong>.</> : <>The contract is <strong>paused</strong>.</>}<br />
             Please come back during the next sale!
           </div>

--- a/minting-dapp/src/scripts/react/MintWidget.tsx
+++ b/minting-dapp/src/scripts/react/MintWidget.tsx
@@ -17,10 +17,12 @@ interface Props {
 
 interface State {
   mintAmount: number;
+  isLoading: boolean;
 }
 
 const defaultState: State = {
   mintAmount: 1,
+  isLoading: false,
 };
 
 export default class MintWidget extends React.Component<Props, State> {
@@ -52,7 +54,9 @@ export default class MintWidget extends React.Component<Props, State> {
 
   private async mint(): Promise<void> {
     if (!this.props.isPaused) {
-      await this.props.mintTokens(this.state.mintAmount);
+      this.setState({ isLoading: true });
+      await this.props.mintTokens(this.state.mintAmount)
+      this.setState({ isLoading: false });
 
       return;
     }
@@ -74,10 +78,10 @@ export default class MintWidget extends React.Component<Props, State> {
             </div>
 
             <div className="controls">
-              <button className="decrease" onClick={() => this.decrementMintAmount()}>-</button>
+              <button className="decrease" onClick={() => this.decrementMintAmount()} disabled={this.state.isLoading}>-</button>
               <span className="mint-amount">{this.state.mintAmount}</span>
-              <button className="increase" onClick={() => this.incrementMintAmount()}>+</button>
-              <button className="primary" onClick={() => this.mint()}>Mint</button>
+              <button className="increase" onClick={() => this.incrementMintAmount()} disabled={this.state.isLoading}>+</button>
+              <button className="primary" onClick={() => this.mint()} disabled={this.state.isLoading}>Mint</button>
             </div>
           </div>
           :

--- a/minting-dapp/src/scripts/react/MintWidget.tsx
+++ b/minting-dapp/src/scripts/react/MintWidget.tsx
@@ -17,12 +17,10 @@ interface Props {
 
 interface State {
   mintAmount: number;
-  isLoading: boolean;
 }
 
 const defaultState: State = {
   mintAmount: 1,
-  isLoading: false,
 };
 
 export default class MintWidget extends React.Component<Props, State> {
@@ -54,9 +52,7 @@ export default class MintWidget extends React.Component<Props, State> {
 
   private async mint(): Promise<void> {
     if (!this.props.isPaused) {
-      this.setState({ isLoading: true });
-      await this.props.mintTokens(this.state.mintAmount)
-      this.setState({ isLoading: false });
+      await this.props.mintTokens(this.state.mintAmount);
 
       return;
     }
@@ -78,10 +74,10 @@ export default class MintWidget extends React.Component<Props, State> {
             </div>
 
             <div className="controls">
-              <button className="decrease" onClick={() => this.decrementMintAmount()} disabled={this.state.isLoading}>-</button>
+              <button className="decrease" onClick={() => this.decrementMintAmount()}>-</button>
               <span className="mint-amount">{this.state.mintAmount}</span>
-              <button className="increase" onClick={() => this.incrementMintAmount()} disabled={this.state.isLoading}>+</button>
-              <button className="primary" onClick={() => this.mint()} disabled={this.state.isLoading}>Mint</button>
+              <button className="increase" onClick={() => this.incrementMintAmount()}>+</button>
+              <button className="primary" onClick={() => this.mint()}>Mint</button>
             </div>
           </div>
           :

--- a/minting-dapp/src/styles/components/minting-dapp.scss
+++ b/minting-dapp/src/styles/components/minting-dapp.scss
@@ -221,4 +221,31 @@
       }
     }
   }
+
+  .mint-initiated {
+    @apply flex flex-col;
+    @apply rounded-lg;
+    @apply p-3;
+    @apply text-sm;
+    @apply bg-green-50;
+    @apply border border-green-200;
+    @apply shadow;
+    @apply text-green-700;
+
+    p {
+      @apply py-2;
+    }
+
+    ul {
+      @apply list-disc;
+      @apply list-inside;
+    }
+
+    &::before {
+      content: 'Mint Initiated!';
+
+      @apply font-semibold;
+      @apply text-base;
+    }
+  }
 }

--- a/minting-dapp/src/styles/components/minting-dapp.scss
+++ b/minting-dapp/src/styles/components/minting-dapp.scss
@@ -221,31 +221,4 @@
       }
     }
   }
-
-  .mint-initiated {
-    @apply flex flex-col;
-    @apply rounded-lg;
-    @apply p-3;
-    @apply text-sm;
-    @apply bg-green-50;
-    @apply border border-green-200;
-    @apply shadow;
-    @apply text-green-700;
-
-    p {
-      @apply py-2;
-    }
-
-    ul {
-      @apply list-disc;
-      @apply list-inside;
-    }
-
-    &::before {
-      content: 'Mint Initiated!';
-
-      @apply font-semibold;
-      @apply text-base;
-    }
-  }
 }

--- a/minting-dapp/yarn.lock
+++ b/minting-dapp/yarn.lock
@@ -2712,6 +2712,11 @@ clone@^2.0.0, clone@^2.1.1:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -6115,6 +6120,13 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-toastify@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.0.3.tgz#8e6d22651c85cb584c5ebd0b5e2c3bf0d7ec06ee"
+  integrity sha512-0QZJk0SqYBxouRBGCFU3ymvjlwimRRhVH7SzqGRiVrQ001KSoUNbGKx9Yq42aoPv18n45yJzEFG82zqv3HnASg==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^17.0.2:
   version "17.0.2"

--- a/smart-contract/lib/NetworkConfigInterface.ts
+++ b/smart-contract/lib/NetworkConfigInterface.ts
@@ -4,5 +4,6 @@ export default interface NetworkConfigInterface {
   blockExplorer: {
     name: string;
     generateContractUrl: (contractAddress: string) => string;
+    generateTransactionUrl: (transactionAddress: string) => string;
   };
 };

--- a/smart-contract/lib/NetworkConfigInterface.ts
+++ b/smart-contract/lib/NetworkConfigInterface.ts
@@ -4,5 +4,7 @@ export default interface NetworkConfigInterface {
   blockExplorer: {
     name: string;
     generateContractUrl: (contractAddress: string) => string;
+    generateTransactionUrl: (transctionId: string) => string;
+    generateTokenUrl: (contractAddress: string) => string;
   };
 };

--- a/smart-contract/lib/NetworkConfigInterface.ts
+++ b/smart-contract/lib/NetworkConfigInterface.ts
@@ -4,7 +4,5 @@ export default interface NetworkConfigInterface {
   blockExplorer: {
     name: string;
     generateContractUrl: (contractAddress: string) => string;
-    generateTransactionUrl: (transctionId: string) => string;
-    generateTokenUrl: (contractAddress: string) => string;
   };
 };

--- a/smart-contract/lib/Networks.ts
+++ b/smart-contract/lib/Networks.ts
@@ -9,6 +9,7 @@ export const hardhatLocal: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Block explorer (not available for local chains)',
     generateContractUrl: (contractAddress: string) => `#`,
+    generateTransactionUrl: (transactionAddress: string) => `#`,
   },
 }
 
@@ -21,6 +22,7 @@ export const ethereumTestnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Etherscan (Rinkeby)',
     generateContractUrl: (contractAddress: string) => `https://rinkeby.etherscan.io/address/${contractAddress}`,
+    generateTransactionUrl: (transactionAddress: string) => `https://rinkeby.etherscan.io/tx/${transactionAddress}`,
   },
 }
 
@@ -30,6 +32,7 @@ export const ethereumMainnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Etherscan',
     generateContractUrl: (contractAddress: string) => `https://etherscan.io/address/${contractAddress}`,
+    generateTransactionUrl: (transactionAddress: string) => `https://etherscan.io/tx/${transactionAddress}`,
   },
 }
 
@@ -42,6 +45,7 @@ export const polygonTestnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Polygonscan (Mumbai)',
     generateContractUrl: (contractAddress: string) => `https://mumbai.polygonscan.com/address/${contractAddress}`,
+    generateTransactionUrl: (transactionAddress: string) => `https://mumbai.polygonscan.com/tx/${transactionAddress}`,
   },
 }
 
@@ -51,5 +55,6 @@ export const polygonMainnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Polygonscan',
     generateContractUrl: (contractAddress: string) => `https://polygonscan.com/address/${contractAddress}`,
+    generateTransactionUrl: (transactionAddress: string) => `https://polygonscan.com/tx/${transactionAddress}`,
   },
 }

--- a/smart-contract/lib/Networks.ts
+++ b/smart-contract/lib/Networks.ts
@@ -9,8 +9,6 @@ export const hardhatLocal: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Block explorer (not available for local chains)',
     generateContractUrl: (contractAddress: string) => `#`,
-    generateTransactionUrl: (transctionId: string) => `#`,
-    generateTokenUrl: (contractAddress: string) => `#`,
   },
 }
 
@@ -23,8 +21,6 @@ export const ethereumTestnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Etherscan (Rinkeby)',
     generateContractUrl: (contractAddress: string) => `https://rinkeby.etherscan.io/address/${contractAddress}`,
-    generateTransactionUrl: (transctionId: string) => `https://rinkeby.etherscan.io/tx/${transctionId}`,
-    generateTokenUrl: (contractAddress: string) => `https://rinkeby.etherscan.io/token/${contractAddress}`,
   },
 }
 
@@ -34,8 +30,6 @@ export const ethereumMainnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Etherscan',
     generateContractUrl: (contractAddress: string) => `https://etherscan.io/address/${contractAddress}`,
-    generateTransactionUrl: (transctionId: string) => `https://etherscan.io/tx/${transctionId}`,
-    generateTokenUrl: (contractAddress: string) => `https://etherscan.io/token/${contractAddress}`,
   },
 }
 
@@ -48,8 +42,6 @@ export const polygonTestnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Polygonscan (Mumbai)',
     generateContractUrl: (contractAddress: string) => `https://mumbai.polygonscan.com/address/${contractAddress}`,
-    generateTransactionUrl: (transctionId: string) => `https://mumbai.polygonscan.com/tx/${transctionId}`,
-    generateTokenUrl: (contractAddress: string) => `https://mumbai.polygonscan.com/token/${contractAddress}`,
   },
 }
 
@@ -59,7 +51,5 @@ export const polygonMainnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Polygonscan',
     generateContractUrl: (contractAddress: string) => `https://polygonscan.com/address/${contractAddress}`,
-    generateTransactionUrl: (transctionId: string) => `https://polygonscan.com/tx/${transctionId}`,
-    generateTokenUrl: (contractAddress: string) => `https://polygonscan.com/token/${contractAddress}`,
   },
 }

--- a/smart-contract/lib/Networks.ts
+++ b/smart-contract/lib/Networks.ts
@@ -9,6 +9,8 @@ export const hardhatLocal: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Block explorer (not available for local chains)',
     generateContractUrl: (contractAddress: string) => `#`,
+    generateTransactionUrl: (transctionId: string) => `#`,
+    generateTokenUrl: (contractAddress: string) => `#`,
   },
 }
 
@@ -21,6 +23,8 @@ export const ethereumTestnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Etherscan (Rinkeby)',
     generateContractUrl: (contractAddress: string) => `https://rinkeby.etherscan.io/address/${contractAddress}`,
+    generateTransactionUrl: (transctionId: string) => `https://rinkeby.etherscan.io/tx/${transctionId}`,
+    generateTokenUrl: (contractAddress: string) => `https://rinkeby.etherscan.io/token/${contractAddress}`,
   },
 }
 
@@ -30,6 +34,8 @@ export const ethereumMainnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Etherscan',
     generateContractUrl: (contractAddress: string) => `https://etherscan.io/address/${contractAddress}`,
+    generateTransactionUrl: (transctionId: string) => `https://etherscan.io/tx/${transctionId}`,
+    generateTokenUrl: (contractAddress: string) => `https://etherscan.io/token/${contractAddress}`,
   },
 }
 
@@ -42,6 +48,8 @@ export const polygonTestnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Polygonscan (Mumbai)',
     generateContractUrl: (contractAddress: string) => `https://mumbai.polygonscan.com/address/${contractAddress}`,
+    generateTransactionUrl: (transctionId: string) => `https://mumbai.polygonscan.com/tx/${transctionId}`,
+    generateTokenUrl: (contractAddress: string) => `https://mumbai.polygonscan.com/token/${contractAddress}`,
   },
 }
 
@@ -51,5 +59,7 @@ export const polygonMainnet: NetworkConfigInterface = {
   blockExplorer: {
     name: 'Polygonscan',
     generateContractUrl: (contractAddress: string) => `https://polygonscan.com/address/${contractAddress}`,
+    generateTransactionUrl: (transctionId: string) => `https://polygonscan.com/tx/${transctionId}`,
+    generateTokenUrl: (contractAddress: string) => `https://polygonscan.com/token/${contractAddress}`,
   },
 }


### PR DESCRIPTION
On mint, disables action buttons and renders a success message with details on how to track and view the NFT. Confirmation button allows to refresh dapp to mint another NFT. Further discussion in issue #11.

Below is a video of the flow:

https://user-images.githubusercontent.com/892152/160469122-21203433-3efb-4b96-a317-94f3bf41c85e.mov


