### PR TITLE
Support native mobile minting

### DIFF
--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -68,6 +68,12 @@ export default class Dapp extends React.Component<Props, State> {
           We were not able to detect <strong>MetaMask</strong>. We value <strong>privacy and security</strong> a lot so we limit the wallet options on the DAPP.<br />
           <br />
           But don't worry! <span className="emoji">😃</span> You can always interact with the smart-contract through <a href={this.generateContractUrl()} target="_blank">{this.state.networkConfig.blockExplorer.name}</a> and <strong>we do our best to provide you with the best user experience possible</strong>, even from there.<br />
+          {this.isMobile() ?
+            <>
+              <br />
+              Already have MetaMask installed? <a href={this.generateMetaMaskDeepLink()}><strong>Long-press here</strong></a> and choose <strong>Open in "MetaMask"</strong> to interact within the in-app browser.<br />
+            </>
+            : null}
           <br />
           You can also get your <strong>Whitelist Proof</strong> manually, using the tool below.
         </>,
@@ -117,6 +123,16 @@ export default class Dapp extends React.Component<Props, State> {
   private isNotMainnet(): boolean
   {
     return this.state.network !== null && this.state.network.chainId !== CollectionConfig.mainnet.chainId;
+  }
+
+  private isMobile(): boolean
+  {
+    return /Android|iPhone|iPad/i.test(navigator.userAgent);
+  }
+
+  private generateMetaMaskDeepLink(): string
+  {
+    return `https://metamask.app.link/dapp/${window.location.href.replace(window.location.protocol + '//', '')}`;
   }
 
   private copyMerkleProofToClipboard(): void

--- a/minting-dapp/src/styles/components/minting-dapp.scss
+++ b/minting-dapp/src/styles/components/minting-dapp.scss
@@ -108,8 +108,8 @@
         @apply w-full;
         
         @apply font-semibold;
-        @apply truncate;
         @apply text-center;
+        overflow-wrap: anywhere;
       }
     }
 


### PR DESCRIPTION
To hint the mobile user to complete the mint in MetaMask's in-app browser:

https://user-images.githubusercontent.com/892152/160477661-d6181311-b7f1-4e53-b02b-a0cc5481db8d.mp4

Also some minor truncation issue with wallet address:

Before | After
--- | ---
![Screen Shot 2022-03-28 at 3 47 36 PM](https://user-images.githubusercontent.com/892152/160477833-feb0fe7f-d0be-4b75-829c-9750bb232a14.png) | ![Screen Shot 2022-03-28 at 3 50 52 PM](https://user-images.githubusercontent.com/892152/160477855-72140b73-8b72-436d-b000-55876eca36c5.png)

