### PR TITLE
Add uriPrefix to constructor to save setup gas

### DIFF
--- a/smart-contract/config/CollectionConfig.ts
+++ b/smart-contract/config/CollectionConfig.ts
@@ -27,6 +27,7 @@ const CollectionConfig: CollectionConfigInterface = {
     maxMintAmountPerTx: 5,
   },
   contractAddress: null,
+  uriPrefix: 'ipfs://__CID__/',
   marketplaceIdentifier: 'my-nft-token',
   marketplaceConfig: Marketplaces.openSea,
   whitelistAddresses: whitelistAddresses,

--- a/smart-contract/config/ContractArguments.ts
+++ b/smart-contract/config/ContractArguments.ts
@@ -9,6 +9,7 @@ const ContractArguments = [
   CollectionConfig.maxSupply,
   CollectionConfig.whitelistSale.maxMintAmountPerTx,
   CollectionConfig.hiddenMetadataUri,
+  CollectionConfig.uriPrefix,
 ] as const;
 
 export default ContractArguments;

--- a/smart-contract/contracts/YourNftToken.sol
+++ b/smart-contract/contracts/YourNftToken.sol
@@ -32,12 +32,14 @@ contract YourNftToken is ERC721A, Ownable, ReentrancyGuard {
     uint256 _cost,
     uint256 _maxSupply,
     uint256 _maxMintAmountPerTx,
-    string memory _hiddenMetadataUri
+    string memory _hiddenMetadataUri,
+    string memory _uriPrefix
   ) ERC721A(_tokenName, _tokenSymbol) {
     setCost(_cost);
     maxSupply = _maxSupply;
     setMaxMintAmountPerTx(_maxMintAmountPerTx);
     setHiddenMetadataUri(_hiddenMetadataUri);
+    setUriPrefix(_uriPrefix);
   }
 
   modifier mintCompliance(uint256 _mintAmount) {

--- a/smart-contract/lib/CollectionConfigInterface.ts
+++ b/smart-contract/lib/CollectionConfigInterface.ts
@@ -18,6 +18,7 @@ export default interface CollectionConfigInterface {
   preSale: SaleConfig;
   publicSale: SaleConfig;
   contractAddress: string|null;
+  uriPrefix: string|null;
   whitelistAddresses: string[];
   marketplaceIdentifier: string;
   marketplaceConfig: MarketplaceConfigInterface,


### PR DESCRIPTION
The URI rarely changes, so I added `uriPrefix` in the constructor so it's part of the deployment step. This saves gas since it avoids a subsequent transaction to set the URI (not sure if there was a reason for that before).