### PR TITLE
Fix sold out logic and sales status

### DIFF
--- a/minting-dapp/src/scripts/react/CollectionStatus.tsx
+++ b/minting-dapp/src/scripts/react/CollectionStatus.tsx
@@ -7,6 +7,7 @@ interface Props {
   isPaused: boolean;
   isWhitelistMintEnabled: boolean;
   isUserInWhitelist: boolean;
+  isSoldOut: boolean;
 }
 
 interface State {
@@ -24,7 +25,7 @@ export default class CollectionStatus extends React.Component<Props, State> {
 
   private isSaleOpen(): boolean
   {
-    return this.props.isWhitelistMintEnabled || !this.props.isPaused;
+    return (this.props.isWhitelistMintEnabled || !this.props.isPaused) && !this.props.isSoldOut;
   }
 
   render() {

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -111,7 +111,7 @@ export default class Dapp extends React.Component<Props, State> {
 
   private isSoldOut(): boolean
   {
-    return this.state.maxSupply !== 0 && this.state.totalSupply < this.state.maxSupply;
+    return this.state.maxSupply !== 0 && this.state.totalSupply >= this.state.maxSupply;
   }
 
   private isNotMainnet(): boolean
@@ -165,8 +165,9 @@ export default class Dapp extends React.Component<Props, State> {
                   isPaused={this.state.isPaused}
                   isWhitelistMintEnabled={this.state.isWhitelistMintEnabled}
                   isUserInWhitelist={this.state.isUserInWhitelist}
+                  isSoldOut={this.isSoldOut()}
                 />
-                {this.state.totalSupply < this.state.maxSupply ?
+                {!this.isSoldOut() ?
                   <MintWidget
                     networkConfig={this.state.networkConfig}
                     maxSupply={this.state.maxSupply}
@@ -198,9 +199,7 @@ export default class Dapp extends React.Component<Props, State> {
               </div>
             }
           </>
-        : null}
-
-        {!this.isWalletConnected() || !this.isSoldOut() ?
+        :
           <div className="no-wallet">
             {!this.isWalletConnected() ? <button className="primary" disabled={this.provider === undefined} onClick={() => this.connectWallet()}>Connect Wallet</button> : null}
             
@@ -225,7 +224,7 @@ export default class Dapp extends React.Component<Props, State> {
               </div>
               : null}
           </div>
-          : null}
+        }
       </>
     );
   }


### PR DESCRIPTION
The sold out logic was opposite. After fixing it, I could reuse it to properly display the `MintWidget` or sold out message instead of replicating the comparison check logic.

Also, when a wallet is not connected, I don't think any of the contract methods can be called. So there's no reason (or way) to check if the contract is sold out with an unconnected wallet.. is this correct? Because of this, I removed this conditional statement of `!this.isWalletConnected() || !this.isSoldOut()` since sold out will always not work in that case. This also removed the messaging of interacting with Etherscan directly because when it is sold out, what can an end user do in Etherscan?

Lastly, I carried the sold out boolean to the connection status component so it can properly display the sales status as being `Closed` instead of `Open`.

Feel free to let me know any thoughts, changes, or misinterpretations I did.

Before | After
--- | ---
<img width="580" alt="Screen Shot 2022-03-30 at 7 21 15 PM" src="https://user-images.githubusercontent.com/892152/160946614-35aa9333-e808-4554-8e31-0a2233957480.png"> | <img width="580" alt="Screen Shot 2022-03-30 at 7 09 23 PM" src="https://user-images.githubusercontent.com/892152/160946637-984651fb-326e-45a7-a1cd-4795241d6748.png">

