### PR TITLE
Disable whitelisting before enabling pre / public sales

### DIFF
--- a/smart-contract/scripts/4_presale_open.ts
+++ b/smart-contract/scripts/4_presale_open.ts
@@ -27,6 +27,14 @@ async function main() {
 
     await (await contract.setPaused(false)).wait();
   }
+  
+  // Disable whitelist sale (if needed)
+  if (await contract.whitelistMintEnabled()) {
+    console.log('Disabling whitelist sale...');
+
+    await (await contract.setWhitelistMintEnabled(false)).wait();
+    console.log('Whitelist sale has been disabled!');
+  }
 
   console.log('Pre-sale is now open!');
 }

--- a/smart-contract/scripts/6_public_sale_open.ts
+++ b/smart-contract/scripts/6_public_sale_open.ts
@@ -27,6 +27,14 @@ async function main() {
 
     await (await contract.setPaused(false)).wait();
   }
+  
+  // Disable whitelist sale (if needed)
+  if (await contract.whitelistMintEnabled()) {
+    console.log('Disabling whitelist sale...');
+
+    await (await contract.setWhitelistMintEnabled(false)).wait();
+    console.log('Whitelist sale has been disabled!');
+  }
 
   console.log('Public sale is now open!');
 }


### PR DESCRIPTION
If a presales or public sales is enabled while whitelisting is enabled, it leaves the dapp in an invalid state. On the left, I enabled public sales when whitelisting was enabled. The sales status shows whitelisting only and public sales price. On the right, it was corrected.

I'm open to discussion because it could be argued that this is a user error and they should know to disable whitelisting before pre/public sales. So this may be more of a convenience and guarding against user error.

Before | After
--- | ---
<img width="580" alt="Screen Shot 2022-03-31 at 11 12 59 AM" src="https://user-images.githubusercontent.com/892152/161090721-38a6e51c-e2a4-4b4a-aac7-3c6c01ec6b7c.png"> | <img width="580" alt="Screen Shot 2022-03-31 at 11 14 47 AM" src="https://user-images.githubusercontent.com/892152/161090761-8342d481-7b75-4430-b6fd-69603dbc0a50.png">