### PR TITLE
Improving walletOfOwner efficiency

### DIFF
--- a/smart-contract/contracts/YourNftToken.sol
+++ b/smart-contract/contracts/YourNftToken.sol
@@ -80,9 +80,9 @@ contract YourNftToken is ERC721A, Ownable, ReentrancyGuard {
     address latestOwnerAddress;
 
     while (ownedTokenIndex < ownerTokenCount && currentTokenId <= maxSupply) {
-      if (_exists(currentTokenId)) {
-        TokenOwnership memory ownership = _ownerships[currentTokenId];
+      TokenOwnership memory ownership = _ownerships[currentTokenId];
 
+      if (!ownership.burned) {
         if (ownership.addr != address(0)) {
           latestOwnerAddress = ownership.addr;
         }


### PR DESCRIPTION
From the [`ERC721A` implementation](https://github.com/chiru-labs/ERC721A/blob/f1f202c782930a74951b52574d53904972303ad1/contracts/ERC721A.sol#L328-L330):
```solidity
    /**
     * @dev Returns whether `tokenId` exists.
     *
     * Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
     *
     * Tokens start existing when they are minted (`_mint`),
     */
    function _exists(uint256 tokenId) internal view returns (bool) {
        return _startTokenId() <= tokenId && tokenId < _currentIndex && !_ownerships[tokenId].burned;
    }
```

In our case `_startTokenId() <= tokenId && tokenId < _currentIndex` are implicitly true when we get to the following line:
https://github.com/hashlips-lab/nft-erc721-collection/blob/5886b1ea9e266c3c214cd18129a58fd631545390/smart-contract/contracts/YourNftToken.sol#L83

This means that the function can be replaced by `!_ownerships[tokenId].burned` only.