### PR TITLE
Integrate RainbowKit for connect wallet flow

### DIFF
--- a/minting-dapp/package.json
+++ b/minting-dapp/package.json
@@ -13,7 +13,7 @@
         "autoprefixer": "^10.4.0",
         "buffer": "^6.0.3",
         "core-js": "^3.0.0",
-        "ethers": "^5.5.3",
+        "ethers": "^5.6.7",
         "file-loader": "^6.0.0",
         "hardhat-typechain": "^0.3.5",
         "keccak256": "^1.0.6",
@@ -30,6 +30,10 @@
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.4",
         "webpack-notifier": "^1.6.0"
+    },
+    "dependencies": {
+        "@rainbow-me/rainbowkit": "^0.1.1",
+        "wagmi": "^0.3.5"
     },
     "scripts": {
         "dev-server": "encore dev-server",

--- a/minting-dapp/src/scripts/main.tsx
+++ b/minting-dapp/src/scripts/main.tsx
@@ -4,10 +4,46 @@ import ReactDOM from 'react-dom';
 import Dapp from './react/Dapp';
 import CollectionConfig from '../../../smart-contract/config/CollectionConfig';
 
+import '@rainbow-me/rainbowkit/styles.css';
+import {
+  apiProvider,
+  configureChains,
+  getDefaultWallets,
+  RainbowKitProvider,
+} from '@rainbow-me/rainbowkit';
+import { chain, createClient, WagmiProvider } from 'wagmi';
+
+// TODO: Map from selected network
+const { chains, provider } = configureChains(
+  [chain.rinkeby],
+  [
+    apiProvider.alchemy(process.env.ALCHEMY_TESTNET_ID),
+    apiProvider.fallback()
+  ]
+);
+
+const { connectors } = getDefaultWallets({
+  appName: document.title || CollectionConfig.tokenName,
+  chains
+});
+
+const wagmiClient = createClient({
+  autoConnect: true,
+  connectors,
+  provider
+})
+
 if (document.title === '') {
   document.title = CollectionConfig.tokenName;
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-  ReactDOM.render(<Dapp />, document.getElementById('minting-dapp'));
+  ReactDOM.render(
+    <WagmiProvider client={wagmiClient}>
+      <RainbowKitProvider chains={chains}>
+        <Dapp/>
+      </RainbowKitProvider>
+    </WagmiProvider>,
+    document.getElementById('minting-dapp')
+  );
 });

--- a/minting-dapp/src/scripts/react/Dapp.tsx
+++ b/minting-dapp/src/scripts/react/Dapp.tsx
@@ -8,6 +8,8 @@ import NetworkConfigInterface from '../../../../smart-contract/lib/NetworkConfig
 import CollectionStatus from './CollectionStatus';
 import MintWidget from './MintWidget';
 import Whitelist from '../lib/Whitelist';
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import '@rainbow-me/rainbowkit/styles.css';
 
 const ContractAbi = require('../../../../smart-contract/artifacts/contracts/' + CollectionConfig.contractName + '.sol/' + CollectionConfig.contractName + '.json').abi;
 
@@ -61,18 +63,6 @@ export default class Dapp extends React.Component<Props, State> {
 
   componentDidMount = async () => {
     const browserProvider = await detectEthereumProvider() as ExternalProvider;
-
-    if (browserProvider?.isMetaMask !== true) {
-      this.setError( 
-        <>
-          We were not able to detect <strong>MetaMask</strong>. We value <strong>privacy and security</strong> a lot so we limit the wallet options on the DAPP.<br />
-          <br />
-          But don't worry! <span className="emoji">😃</span> You can always interact with the smart-contract through <a href={this.generateContractUrl()} target="_blank">{this.state.networkConfig.blockExplorer.name}</a> and <strong>we do our best to provide you with the best user experience possible</strong>, even from there.<br />
-          <br />
-          You can also get your <strong>Whitelist Proof</strong> manually, using the tool below.
-        </>,
-      );
-    }
 
     this.provider = new ethers.providers.Web3Provider(browserProvider);
 
@@ -202,7 +192,7 @@ export default class Dapp extends React.Component<Props, State> {
 
         {!this.isWalletConnected() || !this.isSoldOut() ?
           <div className="no-wallet">
-            {!this.isWalletConnected() ? <button className="primary" disabled={this.provider === undefined} onClick={() => this.connectWallet()}>Connect Wallet</button> : null}
+            {!this.isWalletConnected() ? <ConnectButton/> : null}
             
             <div className="use-block-explorer">
               Hey, looking for a <strong>super-safe experience</strong>? <span className="emoji">😃</span><br />
@@ -266,17 +256,6 @@ export default class Dapp extends React.Component<Props, State> {
     return CollectionConfig.marketplaceConfig.generateCollectionUrl(CollectionConfig.marketplaceIdentifier, !this.isNotMainnet());
   }
 
-  private async connectWallet(): Promise<void>
-  {
-    try {
-      await this.provider.provider.request!({ method: 'eth_requestAccounts' });
-
-      this.initWallet();
-    } catch (e) {
-      this.setError(e);
-    }
-  }
-
   private async initWallet(): Promise<void>
   {
     const walletAccounts = await this.provider.listAccounts();
@@ -316,7 +295,7 @@ export default class Dapp extends React.Component<Props, State> {
       CollectionConfig.contractAddress!,
       ContractAbi,
       this.provider.getSigner(),
-    ) as NftContractType;
+    ) as unknown as NftContractType;
 
     this.setState({
       maxSupply: (await this.contract.maxSupply()).toNumber(),

--- a/minting-dapp/src/styles/main.scss
+++ b/minting-dapp/src/styles/main.scss
@@ -4,3 +4,4 @@
 
 @import './components/general.scss';
 @import './components/minting-dapp.scss';
+@import '@rainbow-me/rainbowkit/styles.css';

--- a/minting-dapp/tailwind.config.js
+++ b/minting-dapp/tailwind.config.js
@@ -2,6 +2,9 @@ const colors = require('tailwindcss/colors');
 
 module.exports = {
   mode: 'jit',
+  corePlugins: {
+    preflight: false,
+  },
   content: [
     './src/**/*.tsx',
     './public/index.html',


### PR DESCRIPTION
To integrate multiple wallets and also a better non-crypto native user experience, using [RainbowKit](https://www.rainbowkit.com) to handle the connect wallet flow. Also includes a mobile experience where it bounces the user back and forth between the minting dapp and the selected crypto wallet (see second attached video). This seems like a lighter and better user experience than [WalletConnect](https://walletconnect.com).

However, I could not overcome a few issues at the moment which is why this is a draft pull request:

1. Existing styles seem a little conflicted such as the connect button, lost padding, whitelisting section, and top screen bounces when modal comes up.
2. Currently hardcoding to Rinkeby but needs to map current test/main chain to [wagmi](https://wagmi.sh) chain in `main.tsx`. I did not want to bring in `wagmi` as a dependency into the `smart-contract` project for `lib/Network.ts`.
3. If MetaMask is installed, the dapp should attempt to connect to MetaMask instead of opening the RainbowKit modal when the connect button is clicked. 
4. Once the wallet is connected, I believe the state should be flushed from RainbowKit to prevent memory leaks since at this RainbowKit is no longer used after this point.5. 
5. Not sure if this is correct, but I don't think I have to use wagmi `useAccount` or `useConnect` hook since the entire dapp is wrapped in `WagmiProvider` and re-renders everything. 

https://user-images.githubusercontent.com/892152/169892269-4cef4e4e-3dc5-410f-a3ac-dd733527602d.mov

https://user-images.githubusercontent.com/892152/169894985-42cab29d-b5b8-4358-bc21-052136f198df.mov



