### PR TITLE
Adding support for custom placeholder color in input fields

### DIFF
--- a/minting-dapp/src/styles/components/general.scss
+++ b/minting-dapp/src/styles/components/general.scss
@@ -139,6 +139,11 @@ input[type=text] {
       @apply cursor-not-allowed;
     }
   }
+
+  &::placeholder {
+    @apply text-txt_input-placeholder_txt;
+    @apply opacity-50;
+  }
 }
 
 label {

--- a/minting-dapp/tailwind.config.js
+++ b/minting-dapp/tailwind.config.js
@@ -69,6 +69,7 @@ module.exports = {
           focus_txt: colors.indigo[600],
           focus_bg: colors.slate[50],
           focus_border: colors.indigo[300],
+          placeholder_txt: colors.indigo[600],
         },
         
         // Whitelist proof widget


### PR DESCRIPTION
The placeholder color for text inputs could not be easily customized without this additional color option.