### PR TITLE
Switching to Goerli as official testnet for Ethereum

### DIFF
--- a/smart-contract/lib/Networks.ts
+++ b/smart-contract/lib/Networks.ts
@@ -17,6 +17,16 @@ export const hardhatLocal: NetworkConfigInterface = {
  * Ethereum
  */
 export const ethereumTestnet: NetworkConfigInterface = {
+  chainId: 5,
+  symbol: 'ETH (test)',
+  blockExplorer: {
+    name: 'Etherscan (Goerli)',
+    generateContractUrl: (contractAddress: string) => `https://goerli.etherscan.io/address/${contractAddress}`,
+    generateTransactionUrl: (transactionAddress: string) => `https://goerli.etherscan.io/tx/${transactionAddress}`,
+  },
+}
+
+export const ethereumLegacyTestnet: NetworkConfigInterface = {
   chainId: 4,
   symbol: 'ETH (test)',
   blockExplorer: {


### PR DESCRIPTION
The default `Networks.ethereumTestnet` now points to Goerli, Rinkeby can still be used as `Networks.ethereumLegacyTestnet`.